### PR TITLE
Change capability for submenu items

### DIFF
--- a/plugin-columns.php
+++ b/plugin-columns.php
@@ -39,7 +39,7 @@ function plugin_columns_add_pinned_categories() {
 				'plugins.php',
 				$pinned_category,
 				$pinned_category,
-				'manage_options',
+				'activate_plugins',
 				str_replace( ' ', '+', $pinned_category) .'-plugin-columns-category-page',				
 				function(){}
 			);


### PR DESCRIPTION
By default, wordpress only shows the plugins list to users who have the role "activate_plugins". Lets not add the submenu pages unless the current user has that capability.